### PR TITLE
chore: Update dependencies for Docker actions in workflow

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -53,23 +53,23 @@ jobs:
           swap-storage: false
 
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       # Install the cosign tool except on PR
       # https://github.com/sigstore/cosign-installer
       - name: Install cosign
         if: github.ref_type == 'tag'
-        uses: sigstore/cosign-installer@v4.0.0
+        uses: sigstore/cosign-installer@v4.1.2
         with:
-          cosign-release: 'v3.0.5'
+          cosign-release: 'v3.0.6'
 
       # https://github.com/docker/build-push-action
       - name: Setup Docker buildx
-        uses: docker/setup-buildx-action@v3.12.0
+        uses: docker/setup-buildx-action@v4.0.0
 
       # https://github.com/docker/login-action
       - name: Log into registry ${{ env.REGISTRY }}
-        uses: docker/login-action@v3.7.0
+        uses: docker/login-action@v4.1.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -78,7 +78,7 @@ jobs:
       # https://github.com/docker/metadata-action
       - name: Extract Docker metadata
         id: meta
-        uses: docker/metadata-action@v5.10.0
+        uses: docker/metadata-action@v6.0.0
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/${{ matrix.image }}
           flavor: |
@@ -90,7 +90,7 @@ jobs:
       # https://github.com/docker/build-push-action
       - name: Build and push Docker image
         id: build-and-push
-        uses: docker/build-push-action@v6.18.0
+        uses: docker/build-push-action@v7.1.0
         with:
           context: .
           file: ${{ matrix.image }}/Dockerfile


### PR DESCRIPTION
This pull request updates the dependencies used in the Docker publishing GitHub Actions workflow to their latest major or minor versions. These changes help ensure better compatibility, security, and access to the latest features and bug fixes.

**Dependency version upgrades in workflow:**

* Updated `actions/checkout` action from `v5` to `v6` in `.github/workflows/docker-publish.yml`
* Updated `sigstore/cosign-installer` from `v4.0.0` to `v4.1.2` and `cosign-release` from `v3.0.5` to `v3.0.6`
* Updated Docker-related GitHub Actions:
  - `docker/setup-buildx-action` from `v3.12.0` to `v4.0.0`
  - `docker/login-action` from `v3.7.0` to `v4.1.0`
  - `docker/metadata-action` from `v5.10.0` to `v6.0.0`
  - `docker/build-push-action` from `v6.18.0` to `v7.1.0`